### PR TITLE
Update python_requires version to 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     keywords="chat streamlit streamlit-component",
-    python_requires=">=3.8",
+    python_requires=">=3.6",
     install_requires=[
         # By definition, a Custom Component depends on Streamlit.
         # If your component has other Python dependencies, list


### PR DESCRIPTION
#20 added support for Python 3.6-3.7, so this change reflects that in `setup.py`.

I tested that chat works on Python 3.7.13.